### PR TITLE
Add exit_account to public inputs, added de/serialization, added fuzzing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 
+.idea
 .direnv
 .envrc
 

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -1,6 +1,6 @@
 use crate::circuit::{slice_to_field_elements, CircuitFragment, D, F};
 use crate::inputs::CircuitInputs;
-use plonky2::field::types::{Field, PrimeField64};
+use plonky2::field::types::{Field, Field64, PrimeField64};
 use plonky2::{
     hash::hash_types::{HashOut, HashOutTarget},
     iop::witness::{PartialWitness, WitnessWrite},

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -1,11 +1,11 @@
+use crate::circuit::{slice_to_field_elements, CircuitFragment, D, F};
+use crate::inputs::CircuitInputs;
+use plonky2::field::types::{Field, PrimeField64};
 use plonky2::{
     hash::hash_types::{HashOut, HashOutTarget},
     iop::witness::{PartialWitness, WitnessWrite},
     plonk::circuit_builder::CircuitBuilder,
 };
-use plonky2::field::types::{Field, Field64, PrimeField64};
-use crate::circuit::{slice_to_field_elements, CircuitFragment, D, F};
-use crate::inputs::CircuitInputs;
 
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct ExitAccount([u8; 32]);
@@ -30,7 +30,9 @@ impl ExitAccount {
     /// Decode [u8; 32] from Vec<F> (expects 4 field elements)
     pub fn from_field_elements(elements: &[F]) -> anyhow::Result<Self> {
         if elements.len() < 4 {
-            return Err(anyhow::anyhow!("Expected 4 field elements for ExitAccount address"));
+            return Err(anyhow::anyhow!(
+                "Expected 4 field elements for ExitAccount address"
+            ));
         }
         let mut address = [0u8; 32];
         for i in 0..4 {
@@ -114,7 +116,11 @@ mod tests {
         let exit_account = ExitAccount::new([0u8; 32]);
         let elements = exit_account.to_field_elements();
         assert_eq!(elements.len(), 4, "Expected 4 field elements");
-        assert_eq!(elements, vec![F::ZERO; 4], "Zero address should encode to zero elements");
+        assert_eq!(
+            elements,
+            vec![F::ZERO; 4],
+            "Zero address should encode to zero elements"
+        );
         let decoded = ExitAccount::from_field_elements(&elements)?;
         assert_eq!(exit_account, decoded, "Zero address round-trip failed");
         Ok(())
@@ -127,7 +133,11 @@ mod tests {
         assert_eq!(elements.len(), 4, "Expected 4 field elements");
         // Each element should be u64::MAX (0xFFFFFFFFFFFFFFFF)
         let expected_value = F::from_noncanonical_u64(u64::MAX);
-        assert_eq!(elements, vec![expected_value; 4], "Max address encoding incorrect");
+        assert_eq!(
+            elements,
+            vec![expected_value; 4],
+            "Max address encoding incorrect"
+        );
         let decoded = ExitAccount::from_field_elements(&elements)?;
         assert_eq!(exit_account, decoded, "Max address round-trip failed");
         Ok(())
@@ -137,7 +147,10 @@ mod tests {
     fn test_exit_account_insufficient_elements() {
         let elements = vec![F::ZERO; 3]; // Too few elements
         let result = ExitAccount::from_field_elements(&elements);
-        assert!(result.is_err(), "Decoding with insufficient elements should fail");
+        assert!(
+            result.is_err(),
+            "Decoding with insufficient elements should fail"
+        );
         assert_eq!(
             result.unwrap_err().to_string(),
             "Expected 4 field elements for ExitAccount address"

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -1,6 +1,6 @@
 use crate::circuit::{slice_to_field_elements, CircuitFragment, D, F};
 use crate::inputs::CircuitInputs;
-use plonky2::field::types::{Field, Field64, PrimeField64};
+use plonky2::field::types::{Field, PrimeField64};
 use plonky2::{
     hash::hash_types::{HashOut, HashOutTarget},
     iop::witness::{PartialWitness, WitnessWrite},
@@ -83,6 +83,7 @@ mod tests {
         tests::{build_and_prove_test, setup_test_builder_and_witness},
         C,
     };
+    use plonky2::field::types::Field64;
 
     use super::*;
     use plonky2::plonk::proof::ProofWithPublicInputs;

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -3,16 +3,42 @@ use plonky2::{
     iop::witness::{PartialWitness, WitnessWrite},
     plonk::circuit_builder::CircuitBuilder,
 };
-
+use plonky2::field::types::{Field, Field64, PrimeField64};
 use crate::circuit::{slice_to_field_elements, CircuitFragment, D, F};
 use crate::inputs::CircuitInputs;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct ExitAccount([u8; 32]);
 
 impl ExitAccount {
     pub fn new(address: [u8; 32]) -> Self {
         Self(address)
+    }
+
+    /// Encode [u8; 32] into Vec<F> (4 field elements, 8 bytes each)
+    pub fn to_field_elements(&self) -> Vec<F> {
+        let mut elements = Vec::with_capacity(4);
+        for i in 0..4 {
+            let mut bytes = [0u8; 8];
+            bytes.copy_from_slice(&self.0[i * 8..(i + 1) * 8]);
+            let value = u64::from_le_bytes(bytes);
+            elements.push(F::from_noncanonical_u64(value));
+        }
+        elements
+    }
+
+    /// Decode [u8; 32] from Vec<F> (expects 4 field elements)
+    pub fn from_field_elements(elements: &[F]) -> anyhow::Result<Self> {
+        if elements.len() < 4 {
+            return Err(anyhow::anyhow!("Expected 4 field elements for ExitAccount address"));
+        }
+        let mut address = [0u8; 32];
+        for i in 0..4 {
+            let value = elements[i].to_noncanonical_u64();
+            let bytes = value.to_le_bytes();
+            address[i * 8..(i + 1) * 8].copy_from_slice(&bytes);
+        }
+        Ok(ExitAccount::new(address))
     }
 }
 
@@ -34,6 +60,7 @@ impl CircuitFragment for ExitAccount {
     /// Builds a dummy circuit to include the exit account as a public input.
     fn circuit(builder: &mut CircuitBuilder<F, D>) -> Self::Targets {
         let address = builder.add_virtual_hash_public_input();
+        builder.register_public_inputs(&address.elements);
         ExitAccountTargets { address }
     }
 
@@ -70,5 +97,69 @@ mod tests {
     fn run_circuit() {
         let exit_account = ExitAccount::default();
         run_test(&exit_account).unwrap();
+    }
+
+    #[test]
+    fn test_exit_account_round_trip() -> anyhow::Result<()> {
+        let exit_account = ExitAccount::new([42u8; 32]);
+        let elements = exit_account.to_field_elements();
+        assert_eq!(elements.len(), 4, "Expected 4 field elements");
+        let decoded = ExitAccount::from_field_elements(&elements)?;
+        assert_eq!(exit_account, decoded, "Round-trip failed");
+        Ok(())
+    }
+
+    #[test]
+    fn test_exit_account_zero_address() -> anyhow::Result<()> {
+        let exit_account = ExitAccount::new([0u8; 32]);
+        let elements = exit_account.to_field_elements();
+        assert_eq!(elements.len(), 4, "Expected 4 field elements");
+        assert_eq!(elements, vec![F::ZERO; 4], "Zero address should encode to zero elements");
+        let decoded = ExitAccount::from_field_elements(&elements)?;
+        assert_eq!(exit_account, decoded, "Zero address round-trip failed");
+        Ok(())
+    }
+
+    #[test]
+    fn test_exit_account_max_address() -> anyhow::Result<()> {
+        let exit_account = ExitAccount::new([255u8; 32]);
+        let elements = exit_account.to_field_elements();
+        assert_eq!(elements.len(), 4, "Expected 4 field elements");
+        // Each element should be u64::MAX (0xFFFFFFFFFFFFFFFF)
+        let expected_value = F::from_noncanonical_u64(u64::MAX);
+        assert_eq!(elements, vec![expected_value; 4], "Max address encoding incorrect");
+        let decoded = ExitAccount::from_field_elements(&elements)?;
+        assert_eq!(exit_account, decoded, "Max address round-trip failed");
+        Ok(())
+    }
+
+    #[test]
+    fn test_exit_account_insufficient_elements() {
+        let elements = vec![F::ZERO; 3]; // Too few elements
+        let result = ExitAccount::from_field_elements(&elements);
+        assert!(result.is_err(), "Decoding with insufficient elements should fail");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Expected 4 field elements for ExitAccount address"
+        );
+    }
+
+    #[test]
+    fn test_exit_account_specific_address() -> anyhow::Result<()> {
+        let mut address = [0u8; 32];
+        address[0] = 1;
+        address[31] = 255; // Non-zero first and last bytes
+        let exit_account = ExitAccount::new(address);
+        let elements = exit_account.to_field_elements();
+        assert_eq!(elements.len(), 4, "Expected 4 field elements");
+        // First element: 0x0000000000000001 (little-endian)
+        // Last element: 0xFF00000000000000
+        let expected_first = F::from_canonical_u64(1);
+        let expected_last = F::from_canonical_u64((255u64 << 56) % F::ORDER);
+        assert_eq!(elements[0], expected_first, "First element incorrect");
+        assert_eq!(elements[3], expected_last, "Last element incorrect");
+        let decoded = ExitAccount::from_field_elements(&elements)?;
+        assert_eq!(exit_account, decoded, "Specific address round-trip failed");
+        Ok(())
     }
 }

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -62,7 +62,6 @@ impl CircuitFragment for ExitAccount {
     /// Builds a dummy circuit to include the exit account as a public input.
     fn circuit(builder: &mut CircuitBuilder<F, D>) -> Self::Targets {
         let address = builder.add_virtual_hash_public_input();
-        builder.register_public_inputs(&address.elements);
         ExitAccountTargets { address }
     }
 

--- a/circuit/src/inputs.rs
+++ b/circuit/src/inputs.rs
@@ -45,7 +45,7 @@ pub mod test_helpers {
                 unspendable_account_preimage,
                 storage_proof: default_proof(),
                 root_hash,
-                exit_account: [0u8; 32],
+                exit_account: [254u8; 32],
             }
         }
     }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -54,6 +54,8 @@ impl WormholeVerifier {
 
 #[cfg(test)]
 mod tests {
+    use plonky2::plonk::proof::ProofWithPublicInputs;
+    use wormhole_circuit::exit_account::ExitAccount;
     use super::WormholeVerifier;
     use wormhole_circuit::inputs::CircuitInputs;
     use wormhole_prover::WormholeProver;
@@ -67,4 +69,66 @@ mod tests {
         let verifier = WormholeVerifier::new();
         verifier.verify(proof).unwrap();
     }
+
+    #[test]
+    fn cannot_verify_with_modified_exit_account() {
+        let prover = WormholeProver::new();
+        let inputs = CircuitInputs::default();
+        let mut proof = prover.commit(&inputs).unwrap().prove().unwrap();
+
+        println!("proof before: {:?}", proof.public_inputs);
+        let exit_account = ExitAccount::from_field_elements(&proof.public_inputs[16..20]);
+        println!("exit_account: {:?}", exit_account);
+        let modified_exit_account = ExitAccount::new([8u8; 32]);
+        proof.public_inputs[16..20].copy_from_slice(&modified_exit_account.to_field_elements());
+        println!("proof after: {:?}", proof.public_inputs);
+
+        // proof.public_inputs
+        let verifier = WormholeVerifier::new();
+        let result = verifier.verify(proof);
+        assert!(result.is_err(), "Expected proof to fail with modified exit_account");
+    }
+
+    #[test]
+    fn cannot_verify_with_any_public_input_modification() {
+        let prover = WormholeProver::new();
+        let inputs = CircuitInputs::default();
+        let mut proof = prover.commit(&inputs).unwrap().prove().unwrap();
+        let verifier = WormholeVerifier::new();
+
+        for ix in 0..proof.public_inputs.len() {
+            let mut p = proof.clone();
+            for jx in 0..8 {
+                p.public_inputs[ix].0 ^= 255 << 8 * jx;
+                let result = verifier.verify(p.clone());
+                assert!(result.is_err(), "Expected proof to fail with modified inputs");
+            }
+        }
+    }
+    
+    // #[test]
+    // fn cannot_verify_with_modified_proof() {
+    //     let prover = WormholeProver::new();
+    //     let inputs = CircuitInputs::default();
+    //     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+    //     let verifier = WormholeVerifier::new();
+    //
+    //     let proof_bytes = proof.to_bytes();
+    //     println!("proof length: {:?}", proof_bytes.len());
+    //     for ix in 0..proof_bytes.len() {
+    //         println!("proof_bytes[{}]: {:?}", ix, proof_bytes[ix]);
+    //         let mut b = proof_bytes.clone();
+    //         b[ix] ^= 255;
+    //         let result1 = ProofWithPublicInputs::from_bytes(b, &verifier.circuit_data.common);
+    //         match result1 {
+    //             Ok(p) => {
+    //                 let result2 = verifier.verify(p.clone());
+    //                 assert!(result2.is_err(), "Expected modified proof to fail");
+    //             },
+    //             Err(error) => {
+    //                 continue;
+    //             }
+    //         }
+    //     }
+    // }
 }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -54,9 +54,9 @@ impl WormholeVerifier {
 
 #[cfg(test)]
 mod tests {
+    use super::WormholeVerifier;
     use plonky2::plonk::proof::ProofWithPublicInputs;
     use wormhole_circuit::exit_account::ExitAccount;
-    use super::WormholeVerifier;
     use wormhole_circuit::inputs::CircuitInputs;
     use wormhole_prover::WormholeProver;
 
@@ -86,14 +86,17 @@ mod tests {
         // proof.public_inputs
         let verifier = WormholeVerifier::new();
         let result = verifier.verify(proof);
-        assert!(result.is_err(), "Expected proof to fail with modified exit_account");
+        assert!(
+            result.is_err(),
+            "Expected proof to fail with modified exit_account"
+        );
     }
 
     #[test]
     fn cannot_verify_with_any_public_input_modification() {
         let prover = WormholeProver::new();
         let inputs = CircuitInputs::default();
-        let mut proof = prover.commit(&inputs).unwrap().prove().unwrap();
+        let proof = prover.commit(&inputs).unwrap().prove().unwrap();
         let verifier = WormholeVerifier::new();
 
         for ix in 0..proof.public_inputs.len() {
@@ -101,34 +104,38 @@ mod tests {
             for jx in 0..8 {
                 p.public_inputs[ix].0 ^= 255 << 8 * jx;
                 let result = verifier.verify(p.clone());
-                assert!(result.is_err(), "Expected proof to fail with modified inputs");
+                assert!(
+                    result.is_err(),
+                    "Expected proof to fail with modified inputs"
+                );
             }
         }
     }
-    
-    // #[test]
-    // fn cannot_verify_with_modified_proof() {
-    //     let prover = WormholeProver::new();
-    //     let inputs = CircuitInputs::default();
-    //     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
-    //     let verifier = WormholeVerifier::new();
-    //
-    //     let proof_bytes = proof.to_bytes();
-    //     println!("proof length: {:?}", proof_bytes.len());
-    //     for ix in 0..proof_bytes.len() {
-    //         println!("proof_bytes[{}]: {:?}", ix, proof_bytes[ix]);
-    //         let mut b = proof_bytes.clone();
-    //         b[ix] ^= 255;
-    //         let result1 = ProofWithPublicInputs::from_bytes(b, &verifier.circuit_data.common);
-    //         match result1 {
-    //             Ok(p) => {
-    //                 let result2 = verifier.verify(p.clone());
-    //                 assert!(result2.is_err(), "Expected modified proof to fail");
-    //             },
-    //             Err(error) => {
-    //                 continue;
-    //             }
-    //         }
-    //     }
-    // }
+
+    #[ignore]
+    #[test]
+    fn cannot_verify_with_modified_proof() {
+        let prover = WormholeProver::new();
+        let inputs = CircuitInputs::default();
+        let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+        let verifier = WormholeVerifier::new();
+
+        let proof_bytes = proof.to_bytes();
+        println!("proof length: {:?}", proof_bytes.len());
+        for ix in 0..proof_bytes.len() {
+            println!("proof_bytes[{}]: {:?}", ix, proof_bytes[ix]);
+            let mut b = proof_bytes.clone();
+            b[ix] ^= 255;
+            let result1 = ProofWithPublicInputs::from_bytes(b, &verifier.circuit_data.common);
+            match result1 {
+                Ok(p) => {
+                    let result2 = verifier.verify(p.clone());
+                    assert!(result2.is_err(), "Expected modified proof to fail");
+                }
+                Err(_) => {
+                    continue;
+                }
+            }
+        }
+    }
 }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -77,13 +77,12 @@ mod tests {
         let mut proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
         println!("proof before: {:?}", proof.public_inputs);
-        let exit_account = ExitAccount::from_field_elements(&proof.public_inputs[16..20]);
+        let exit_account = ExitAccount::from_field_elements(&proof.public_inputs[15..19]);
         println!("exit_account: {:?}", exit_account);
         let modified_exit_account = ExitAccount::new([8u8; 32]);
-        proof.public_inputs[16..20].copy_from_slice(&modified_exit_account.to_field_elements());
+        proof.public_inputs[15..19].copy_from_slice(&modified_exit_account.to_field_elements());
         println!("proof after: {:?}", proof.public_inputs);
 
-        // proof.public_inputs
         let verifier = WormholeVerifier::new();
         let result = verifier.verify(proof);
         assert!(


### PR DESCRIPTION
We need exit_account to be registered as a public input. We have tests now confirming that you don't need to explicitly add a constraint for the input to be locked to the proof. I also added a fuzzer that modifies every byte of the proof separately, but it takes forever so I commented it out.