### PR TITLE
feat: aggregator circuit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,5 @@
 [workspace]
-members = [
-    "circuit",
-    "prover",
-    "verifier",
-]
+members = ["aggregator", "circuit", "prover", "verifier"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -13,3 +13,10 @@ poseidon-resonance.workspace = true
 wormhole-circuit = { path = "../circuit" }
 wormhole-prover = { path = "../prover" }
 wormhole-verifier = { path = "../verifier" }
+
+[features]
+testing = [
+  "wormhole-circuit/testing",
+  "wormhole-verifier/testing",
+  "wormhole-prover/testing",
+]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wormhole-aggregator"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+plonky2.workspace = true
+poseidon-resonance.workspace = true
+wormhole-circuit = { path = "../circuit" }
+wormhole-prover = { path = "../prover" }
+wormhole-verifier = { path = "../verifier" }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -14,6 +14,13 @@ wormhole-circuit = { path = "../circuit" }
 wormhole-prover = { path = "../prover" }
 wormhole-verifier = { path = "../verifier" }
 
+[dev-dependencies]
+# This is the same crate as used in plonky2. Need to have it for dummy proofs to work correctly.
+hashbrown = { version = "0.14.3", default-features = false, features = [
+  "ahash",
+  "serde",
+] }
+
 [features]
 testing = [
   "wormhole-circuit/testing",

--- a/aggregator/src/circuit.rs
+++ b/aggregator/src/circuit.rs
@@ -101,6 +101,7 @@ mod tests {
         build_and_prove_test(builder, pw)
     }
 
+    #[ignore = "takes too long"]
     #[test]
     #[cfg(feature = "testing")]
     fn build_and_verify_proof() {

--- a/aggregator/src/circuit.rs
+++ b/aggregator/src/circuit.rs
@@ -1,0 +1,119 @@
+use plonky2::{
+    iop::witness::{PartialWitness, WitnessWrite},
+    plonk::{
+        circuit_data::VerifierCircuitTarget,
+        proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
+    },
+};
+use wormhole_circuit::circuit::{CircuitFragment, C, D, F};
+use wormhole_verifier::WormholeVerifier;
+
+use crate::NUM_PROOFS_TO_AGGREGATE;
+
+pub struct WormholeProofAggregatorTargets {
+    verifier_data: VerifierCircuitTarget,
+    proofs: Vec<ProofWithPublicInputsTarget<D>>,
+}
+
+pub struct WormholeProofAggregatorInputs {
+    proofs: Vec<ProofWithPublicInputs<F, C, D>>,
+}
+
+/// A circuit that aggregates proofs from the Wormhole circuit.
+pub struct WormholeProofAggregator {
+    inner_verifier: WormholeVerifier,
+}
+
+impl Default for WormholeProofAggregator {
+    fn default() -> Self {
+        let inner_verifier = WormholeVerifier::new();
+        Self { inner_verifier }
+    }
+}
+
+impl WormholeProofAggregator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl CircuitFragment for WormholeProofAggregator {
+    type PrivateInputs = WormholeProofAggregatorInputs;
+    type Targets = WormholeProofAggregatorTargets;
+
+    fn circuit(
+        builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
+    ) -> Self::Targets {
+        let circuit_data = WormholeVerifier::new().circuit_data;
+        let verifier_data =
+            builder.add_virtual_verifier_data(circuit_data.common.fri_params.config.cap_height);
+
+        // Setup targets for proofs.
+        let mut proofs = Vec::with_capacity(NUM_PROOFS_TO_AGGREGATE);
+        for _ in 0..NUM_PROOFS_TO_AGGREGATE {
+            proofs.push(builder.add_virtual_proof_with_pis(&circuit_data.common));
+        }
+
+        // Verify each aggregated proof separately.
+        for proof in proofs.iter().take(NUM_PROOFS_TO_AGGREGATE) {
+            builder.verify_proof::<C>(proof, &verifier_data, &circuit_data.common);
+        }
+
+        WormholeProofAggregatorTargets {
+            verifier_data,
+            proofs,
+        }
+    }
+
+    fn fill_targets(
+        &self,
+        pw: &mut PartialWitness<F>,
+        targets: Self::Targets,
+        inputs: Self::PrivateInputs,
+    ) -> anyhow::Result<()> {
+        for (proof_target, proof) in targets.proofs.iter().zip(inputs.proofs.iter()) {
+            pw.set_proof_with_pis_target(proof_target, proof)?;
+        }
+
+        pw.set_verifier_data_target(
+            &targets.verifier_data,
+            &self.inner_verifier.circuit_data.verifier_only,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use wormhole_circuit::circuit::tests::{build_and_prove_test, setup_test_builder_and_witness};
+    use wormhole_circuit::inputs::CircuitInputs;
+    use wormhole_prover::WormholeProver;
+
+    fn run_test(
+        inputs: WormholeProofAggregatorInputs,
+    ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
+        let (mut builder, mut pw) = setup_test_builder_and_witness();
+        let targets = WormholeProofAggregator::circuit(&mut builder);
+
+        let aggregator = WormholeProofAggregator::new();
+        aggregator.fill_targets(&mut pw, targets, inputs).unwrap();
+        build_and_prove_test(builder, pw)
+    }
+
+    #[test]
+    #[cfg(feature = "testing")]
+    fn build_and_verify_proof() {
+        // Create proofs.
+        let mut proofs = Vec::with_capacity(NUM_PROOFS_TO_AGGREGATE);
+        for _ in 0..NUM_PROOFS_TO_AGGREGATE {
+            let prover = WormholeProver::new();
+            let inputs = CircuitInputs::default();
+            let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+            proofs.push(proof);
+        }
+
+        let inputs = WormholeProofAggregatorInputs { proofs };
+        run_test(inputs).unwrap();
+    }
+}

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod aggregator;
 pub mod circuit;
 
 /// The maximum numbers of proofs to aggregate into a composite proof.

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -1,0 +1,53 @@
+use plonky2::plonk::proof::ProofWithPublicInputsTarget;
+use plonky2::{iop::witness::PartialWitness, plonk::circuit_data::VerifierCircuitTarget};
+
+use wormhole_circuit::circuit::{CircuitFragment, C, D, F};
+use wormhole_verifier::WormholeVerifier;
+
+// Constants for the recursion.
+const NUM_PROOFS_TO_AGGREGATE: usize = 10;
+
+pub struct WormholeProofAggregatorTargets {
+    verifier_data: VerifierCircuitTarget,
+    proofs: Vec<ProofWithPublicInputsTarget<D>>,
+}
+
+/// A circuit that aggregates proofs from the Wormhole circuit.
+pub struct WormholeProofAggregator;
+
+impl CircuitFragment for WormholeProofAggregator {
+    type PrivateInputs = ();
+    type Targets = WormholeProofAggregatorTargets;
+
+    fn circuit(
+        builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
+    ) -> Self::Targets {
+        let verifier = WormholeVerifier::new();
+        let verifier_data = builder.add_virtual_verifier_data(NUM_PROOFS_TO_AGGREGATE);
+
+        // Setup targets for proofs.
+        let mut proofs = Vec::with_capacity(NUM_PROOFS_TO_AGGREGATE);
+        for _ in 0..NUM_PROOFS_TO_AGGREGATE {
+            proofs.push(builder.add_virtual_proof_with_pis(&verifier.circuit_data.common));
+        }
+
+        // Verify each aggregated proof separately.
+        for proof in proofs.iter().take(NUM_PROOFS_TO_AGGREGATE) {
+            builder.verify_proof::<C>(proof, &verifier_data, &verifier.circuit_data.common);
+        }
+
+        WormholeProofAggregatorTargets {
+            verifier_data,
+            proofs,
+        }
+    }
+
+    fn fill_targets(
+        &self,
+        pw: &mut PartialWitness<F>,
+        targets: Self::Targets,
+        inputs: Self::PrivateInputs,
+    ) -> anyhow::Result<()> {
+        todo!()
+    }
+}

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -1,53 +1,5 @@
-use plonky2::plonk::proof::ProofWithPublicInputsTarget;
-use plonky2::{iop::witness::PartialWitness, plonk::circuit_data::VerifierCircuitTarget};
+pub mod aggregator;
+pub mod circuit;
 
-use wormhole_circuit::circuit::{CircuitFragment, C, D, F};
-use wormhole_verifier::WormholeVerifier;
-
-// Constants for the recursion.
+/// The maximum numbers of proofs to aggregate into a composite proof.
 const NUM_PROOFS_TO_AGGREGATE: usize = 10;
-
-pub struct WormholeProofAggregatorTargets {
-    verifier_data: VerifierCircuitTarget,
-    proofs: Vec<ProofWithPublicInputsTarget<D>>,
-}
-
-/// A circuit that aggregates proofs from the Wormhole circuit.
-pub struct WormholeProofAggregator;
-
-impl CircuitFragment for WormholeProofAggregator {
-    type PrivateInputs = ();
-    type Targets = WormholeProofAggregatorTargets;
-
-    fn circuit(
-        builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
-    ) -> Self::Targets {
-        let verifier = WormholeVerifier::new();
-        let verifier_data = builder.add_virtual_verifier_data(NUM_PROOFS_TO_AGGREGATE);
-
-        // Setup targets for proofs.
-        let mut proofs = Vec::with_capacity(NUM_PROOFS_TO_AGGREGATE);
-        for _ in 0..NUM_PROOFS_TO_AGGREGATE {
-            proofs.push(builder.add_virtual_proof_with_pis(&verifier.circuit_data.common));
-        }
-
-        // Verify each aggregated proof separately.
-        for proof in proofs.iter().take(NUM_PROOFS_TO_AGGREGATE) {
-            builder.verify_proof::<C>(proof, &verifier_data, &verifier.circuit_data.common);
-        }
-
-        WormholeProofAggregatorTargets {
-            verifier_data,
-            proofs,
-        }
-    }
-
-    fn fill_targets(
-        &self,
-        pw: &mut PartialWitness<F>,
-        targets: Self::Targets,
-        inputs: Self::PrivateInputs,
-    ) -> anyhow::Result<()> {
-        todo!()
-    }
-}

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod circuit;
 
 /// The maximum numbers of proofs to aggregate into a composite proof.
-const NUM_PROOFS_TO_AGGREGATE: usize = 10;
+const MAX_NUM_PROOFS_TO_AGGREGATE: usize = 10;

--- a/circuit/src/circuit.rs
+++ b/circuit/src/circuit.rs
@@ -6,6 +6,7 @@ use crate::exit_account::{ExitAccount, ExitAccountTargets};
 use crate::nullifier::{Nullifier, NullifierTargets};
 use crate::storage_proof::{StorageProof, StorageProofTargets};
 use crate::unspendable_account::{UnspendableAccount, UnspendableAccountTargets};
+use plonky2::plonk::circuit_data::CircuitData;
 use plonky2::{
     field::{goldilocks_field::GoldilocksField, types::Field},
     iop::witness::PartialWitness,
@@ -100,6 +101,10 @@ impl WormholeCircuit {
 
     pub fn targets(&self) -> CircuitTargets {
         self.targets.clone()
+    }
+
+    pub fn build_circuit(self) -> CircuitData<F, C, D> {
+        self.builder.build()
     }
 
     pub fn build_prover(self) -> ProverCircuitData<F, C, D> {

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -41,7 +41,7 @@ use wormhole_circuit::{
 
 #[derive(Debug)]
 pub struct WormholeProver {
-    circuit_data: ProverCircuitData<F, C, D>,
+    pub circuit_data: ProverCircuitData<F, C, D>,
     partial_witness: PartialWitness<F>,
     targets: Option<CircuitTargets>,
 }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -24,7 +24,7 @@ use plonky2::plonk::{circuit_data::VerifierCircuitData, proof::ProofWithPublicIn
 use wormhole_circuit::circuit::{WormholeCircuit, C, D, F};
 
 pub struct WormholeVerifier {
-    circuit_data: VerifierCircuitData<F, C, D>,
+    pub circuit_data: VerifierCircuitData<F, C, D>,
 }
 
 impl Default for WormholeVerifier {


### PR DESCRIPTION
Introduces a new circuit that can aggregate wormhole proofs into a composite proof. The circuit supports any number of proofs up to `MAX_NUM_PROOFS_TO_AGGREGATE`, currently set to 10.

### Next steps

- Add a `WormholeAggregator` that can aggregate wormhole proofs and then prove them via this circuit.
- Add benchmarks for generating and verifying composite proofs.