### PR TITLE
feat: deserialize public inputs

### DIFF
--- a/circuit/src/amounts.rs
+++ b/circuit/src/amounts.rs
@@ -55,8 +55,12 @@ impl FieldElementCodec for Amounts {
 }
 
 impl From<&CircuitInputs> for Amounts {
-    fn from(value: &CircuitInputs) -> Self {
-        Self::new(value.funding_tx_amount, value.exit_amount, value.fee_amount)
+    fn from(inputs: &CircuitInputs) -> Self {
+        Self::new(
+            inputs.public.funding_tx_amount,
+            inputs.public.exit_amount,
+            inputs.public.fee_amount,
+        )
     }
 }
 

--- a/circuit/src/circuit.rs
+++ b/circuit/src/circuit.rs
@@ -6,6 +6,7 @@ use crate::exit_account::{ExitAccount, ExitAccountTargets};
 use crate::nullifier::{Nullifier, NullifierTargets};
 use crate::storage_proof::{StorageProof, StorageProofTargets};
 use crate::unspendable_account::{UnspendableAccount, UnspendableAccountTargets};
+use plonky2::field::types::PrimeField64;
 use plonky2::plonk::circuit_data::CircuitData;
 use plonky2::{
     field::{goldilocks_field::GoldilocksField, types::Field},
@@ -54,6 +55,19 @@ pub fn slice_to_field_elements(input: &[u8]) -> Vec<F> {
     }
 
     field_elements
+}
+
+/// Converts a given field element slice into its byte representation.
+pub fn field_elements_to_bytes(input: &[F]) -> Vec<u8> {
+    let mut bytes: Vec<u8> = Vec::new();
+
+    for field_element in input {
+        let value = field_element.to_noncanonical_u64();
+        let value_bytes = value.to_le_bytes();
+        bytes.extend_from_slice(&value_bytes);
+    }
+
+    bytes
 }
 
 #[derive(Debug, Clone)]

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -48,8 +48,8 @@ impl FieldElementCodec for ExitAccount {
 }
 
 impl From<&CircuitInputs> for ExitAccount {
-    fn from(value: &CircuitInputs) -> Self {
-        Self::new(value.exit_account)
+    fn from(inputs: &CircuitInputs) -> Self {
+        Self::new(inputs.public.exit_account)
     }
 }
 

--- a/circuit/src/inputs.rs
+++ b/circuit/src/inputs.rs
@@ -1,12 +1,28 @@
 /// Inputs required to commit to the wormhole circuit.
 #[derive(Debug)]
 pub struct CircuitInputs {
+    pub public: PublicCircuitInputs,
+    pub private: PrivateCircuitInputs,
+}
+
+/// All of the public inputs required for the circuit.
+#[derive(Debug)]
+pub struct PublicCircuitInputs {
     /// The amount sent in the transaction.
     pub funding_tx_amount: u64,
     /// Amount to be withdrawn.
     pub exit_amount: u64,
     /// The fee for the transaction.
     pub fee_amount: u64,
+    /// The root hash of the storage trie.
+    pub root_hash: [u8; 32],
+    /// The address of the account to pay out to.
+    pub exit_account: [u8; 32],
+}
+
+/// All of the private inputs required for the circuit.
+#[derive(Debug)]
+pub struct PrivateCircuitInputs {
     /// Raw bytes of the nullifier preimage, used to prevent double spends.
     pub nullifier_preimage: Vec<u8>,
     /// Raw bytes of the unspendable account preimage.
@@ -16,20 +32,15 @@ pub struct CircuitInputs {
     /// Each element is a tuple where the items are the left and right splits of a proof node split
     /// in half at the expected childs hash index.
     pub storage_proof: Vec<(Vec<u8>, Vec<u8>)>,
-    /// The root hash of the storage trie.
-    pub root_hash: [u8; 32],
-    /// The address of the account to pay out to.
-    pub exit_account: [u8; 32],
 }
 
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers {
-
     use crate::nullifier;
     use crate::storage_proof::test_helpers::{default_proof, ROOT_HASH};
     use crate::unspendable_account;
 
-    use super::CircuitInputs;
+    use super::{CircuitInputs, PrivateCircuitInputs, PublicCircuitInputs};
 
     impl Default for CircuitInputs {
         fn default() -> Self {
@@ -37,15 +48,20 @@ pub mod test_helpers {
             let unspendable_account_preimage =
                 hex::decode(unspendable_account::test_helpers::PREIMAGES[0]).unwrap();
             let root_hash: [u8; 32] = hex::decode(ROOT_HASH).unwrap().try_into().unwrap();
+
             Self {
-                funding_tx_amount: 0,
-                exit_amount: 0,
-                fee_amount: 0,
-                nullifier_preimage,
-                unspendable_account_preimage,
-                storage_proof: default_proof(),
-                root_hash,
-                exit_account: [254u8; 32],
+                public: PublicCircuitInputs {
+                    funding_tx_amount: 0,
+                    exit_amount: 0,
+                    fee_amount: 0,
+                    root_hash,
+                    exit_account: [254u8; 32],
+                },
+                private: PrivateCircuitInputs {
+                    nullifier_preimage,
+                    unspendable_account_preimage,
+                    storage_proof: default_proof(),
+                },
             }
         }
     }

--- a/circuit/src/nullifier.rs
+++ b/circuit/src/nullifier.rs
@@ -18,7 +18,7 @@ pub const PREIMAGE_NUM_TARGETS: usize = 5;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Nullifier {
-    hash: Digest,
+    pub hash: Digest,
 }
 
 impl Nullifier {

--- a/circuit/src/nullifier.rs
+++ b/circuit/src/nullifier.rs
@@ -50,8 +50,8 @@ impl FieldElementCodec for Nullifier {
 }
 
 impl From<&CircuitInputs> for Nullifier {
-    fn from(value: &CircuitInputs) -> Self {
-        Self::new(&value.nullifier_preimage)
+    fn from(inputs: &CircuitInputs) -> Self {
+        Self::new(&inputs.private.nullifier_preimage)
     }
 }
 

--- a/circuit/src/storage_proof.rs
+++ b/circuit/src/storage_proof.rs
@@ -68,8 +68,8 @@ impl StorageProof {
 }
 
 impl From<&CircuitInputs> for StorageProof {
-    fn from(value: &CircuitInputs) -> Self {
-        Self::new(&value.storage_proof)
+    fn from(inputs: &CircuitInputs) -> Self {
+        Self::new(&inputs.private.storage_proof)
     }
 }
 

--- a/circuit/src/unspendable_account.rs
+++ b/circuit/src/unspendable_account.rs
@@ -20,7 +20,7 @@ pub type AccountId = Digest;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct UnspendableAccount {
-    account_id: AccountId,
+    pub account_id: AccountId,
 }
 
 impl UnspendableAccount {

--- a/circuit/src/unspendable_account.rs
+++ b/circuit/src/unspendable_account.rs
@@ -55,8 +55,8 @@ impl FieldElementCodec for UnspendableAccount {
 }
 
 impl From<&CircuitInputs> for UnspendableAccount {
-    fn from(value: &CircuitInputs) -> Self {
-        Self::new(&value.unspendable_account_preimage)
+    fn from(inputs: &CircuitInputs) -> Self {
+        Self::new(&inputs.private.unspendable_account_preimage)
     }
 }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -84,9 +84,9 @@ impl WormholeProver {
         let storage_proof = StorageProof::from(circuit_inputs);
         let exit_account = ExitAccount::from(circuit_inputs);
 
-        let nullifier_inputs = NullifierInputs::new(&circuit_inputs.nullifier_preimage);
+        let nullifier_inputs = NullifierInputs::new(&circuit_inputs.private.nullifier_preimage);
         let unspendable_account_inputs =
-            UnspendableAccountInputs::new(&circuit_inputs.unspendable_account_preimage);
+            UnspendableAccountInputs::new(&circuit_inputs.private.unspendable_account_preimage);
 
         amounts.fill_targets(&mut self.partial_witness, targets.amounts, ())?;
         nullifier.fill_targets(
@@ -102,7 +102,7 @@ impl WormholeProver {
         storage_proof.fill_targets(
             &mut self.partial_witness,
             targets.storage_proof,
-            StorageProofInputs::new(circuit_inputs.root_hash),
+            StorageProofInputs::new(circuit_inputs.public.root_hash),
         )?;
         exit_account.fill_targets(&mut self.partial_witness, targets.exit_account, ())?;
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -135,4 +135,15 @@ mod tests {
         let inputs = CircuitInputs::default();
         prover.commit(&inputs).unwrap().prove().unwrap();
     }
+
+    #[test]
+    #[ignore = "debug"]
+    #[cfg(feature = "testing")]
+    fn get_public_inputs() {
+        let prover = WormholeProver::new();
+        let inputs = CircuitInputs::default();
+        let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+        let public_inputs = proof.public_inputs;
+        println!("{:?}", public_inputs);
+    }
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -146,4 +146,16 @@ mod tests {
         let public_inputs = proof.public_inputs;
         println!("{:?}", public_inputs);
     }
+
+    #[test]
+    #[cfg(feature = "testing")]
+    fn proof_can_be_deserialized() {
+        use wormhole_circuit::inputs::PublicCircuitInputs;
+
+        let prover = WormholeProver::new();
+        let inputs = CircuitInputs::default();
+        let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+        let public_inputs = PublicCircuitInputs::try_from(proof).unwrap();
+        println!("{:?}", public_inputs);
+    }
 }


### PR DESCRIPTION
- Splits the circuit inputs into public/private.
- Adds a `TryFrom<ProofWithPublicInputs<...>>` implementation to quickly extract all public inputs from a proof generated with the prover.

Note: for now the public inputs, nullifier and unspendable account, are not directly supplied to the circuit. Instead they are computed via the private preimage inputs and supplied that way. Implementing a `from_bytes` on nullifier and unspendable account would hook it into the circuit.