### PR TITLE
ref: circuit fragment state

### DIFF
--- a/aggregator/src/circuit.rs
+++ b/aggregator/src/circuit.rs
@@ -80,12 +80,12 @@ impl CircuitFragment for WormholeProofAggregator {
     type Targets = WormholeProofAggregatorTargets;
 
     fn circuit(
-        Self::Targets {
-            verifier_data,
-            proofs,
+        &Self::Targets {
+            ref verifier_data,
+            ref proofs,
             num_proofs,
-            circuit_data,
-        }: Self::Targets,
+            ref circuit_data,
+        }: &Self::Targets,
         builder: &mut CircuitBuilder<F, D>,
     ) {
         // Verify each aggregated proof separately.
@@ -96,8 +96,8 @@ impl CircuitFragment for WormholeProofAggregator {
                 .conditionally_verify_proof_or_dummy::<C>(
                     is_proof,
                     proof,
-                    &verifier_data,
-                    &circuit_data,
+                    verifier_data,
+                    circuit_data,
                 )
                 .unwrap();
         }
@@ -140,7 +140,7 @@ mod tests {
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let (mut builder, mut pw) = setup_test_builder_and_witness();
         let targets = WormholeProofAggregatorTargets::new(&mut builder);
-        WormholeProofAggregator::circuit(targets.clone(), &mut builder);
+        WormholeProofAggregator::circuit(&targets, &mut builder);
 
         let aggregator = WormholeProofAggregator::new();
         aggregator.fill_targets(&mut pw, targets, inputs).unwrap();

--- a/aggregator/src/circuit.rs
+++ b/aggregator/src/circuit.rs
@@ -5,7 +5,8 @@ use plonky2::{
         witness::{PartialWitness, WitnessWrite},
     },
     plonk::{
-        circuit_data::VerifierCircuitTarget,
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CommonCircuitData, VerifierCircuitTarget},
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
 };
@@ -17,10 +18,38 @@ use wormhole_verifier::WormholeVerifier;
 
 use crate::MAX_NUM_PROOFS_TO_AGGREGATE;
 
+#[derive(Debug, Clone)]
 pub struct WormholeProofAggregatorTargets {
     verifier_data: VerifierCircuitTarget,
     proofs: [ProofWithPublicInputsTarget<D>; MAX_NUM_PROOFS_TO_AGGREGATE],
     num_proofs: Target,
+    // HACK: This allows us to only create `circuit_data` once.
+    circuit_data: CommonCircuitData<F, D>,
+}
+
+impl WormholeProofAggregatorTargets {
+    pub fn new(builder: &mut CircuitBuilder<F, D>) -> Self {
+        let circuit_data = WormholeVerifier::new().circuit_data.common;
+        let verifier_data =
+            builder.add_virtual_verifier_data(circuit_data.fri_params.config.cap_height);
+
+        // Setup targets for proofs.
+        let num_proofs = builder.add_virtual_target();
+        let mut proofs = Vec::with_capacity(MAX_NUM_PROOFS_TO_AGGREGATE);
+        for _ in 0..MAX_NUM_PROOFS_TO_AGGREGATE {
+            proofs.push(builder.add_virtual_proof_with_pis(&circuit_data));
+        }
+
+        let proofs: [ProofWithPublicInputsTarget<D>; MAX_NUM_PROOFS_TO_AGGREGATE] =
+            std::array::from_fn(|_| builder.add_virtual_proof_with_pis(&circuit_data));
+
+        Self {
+            verifier_data,
+            proofs,
+            num_proofs,
+            circuit_data,
+        }
+    }
 }
 
 pub struct WormholeProofAggregatorInputs {
@@ -51,22 +80,14 @@ impl CircuitFragment for WormholeProofAggregator {
     type Targets = WormholeProofAggregatorTargets;
 
     fn circuit(
-        builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
-    ) -> Self::Targets {
-        let circuit_data = WormholeVerifier::new().circuit_data;
-        let verifier_data =
-            builder.add_virtual_verifier_data(circuit_data.common.fri_params.config.cap_height);
-
-        // Setup targets for proofs.
-        let num_proofs = builder.add_virtual_target();
-        let mut proofs = Vec::with_capacity(MAX_NUM_PROOFS_TO_AGGREGATE);
-        for _ in 0..MAX_NUM_PROOFS_TO_AGGREGATE {
-            proofs.push(builder.add_virtual_proof_with_pis(&circuit_data.common));
-        }
-
-        let proofs: [ProofWithPublicInputsTarget<D>; MAX_NUM_PROOFS_TO_AGGREGATE] =
-            std::array::from_fn(|_| builder.add_virtual_proof_with_pis(&circuit_data.common));
-
+        Self::Targets {
+            verifier_data,
+            proofs,
+            num_proofs,
+            circuit_data,
+        }: Self::Targets,
+        builder: &mut CircuitBuilder<F, D>,
+    ) {
         // Verify each aggregated proof separately.
         let n_log = (usize::BITS - (MAX_NUM_PROOFS_TO_AGGREGATE - 1).leading_zeros()) as usize;
         for (i, proof) in proofs.iter().enumerate() {
@@ -76,15 +97,9 @@ impl CircuitFragment for WormholeProofAggregator {
                     is_proof,
                     proof,
                     &verifier_data,
-                    &circuit_data.common,
+                    &circuit_data,
                 )
                 .unwrap();
-        }
-
-        WormholeProofAggregatorTargets {
-            verifier_data,
-            proofs,
-            num_proofs,
         }
     }
 
@@ -124,7 +139,8 @@ mod tests {
         inputs: WormholeProofAggregatorInputs,
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let (mut builder, mut pw) = setup_test_builder_and_witness();
-        let targets = WormholeProofAggregator::circuit(&mut builder);
+        let targets = WormholeProofAggregatorTargets::new(&mut builder);
+        WormholeProofAggregator::circuit(targets.clone(), &mut builder);
 
         let aggregator = WormholeProofAggregator::new();
         aggregator.fill_targets(&mut pw, targets, inputs).unwrap();

--- a/circuit/src/amounts.rs
+++ b/circuit/src/amounts.rs
@@ -62,11 +62,21 @@ impl From<&CircuitInputs> for Amounts {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct AmountsTargets {
     pub funding_tx_amount: Target,
     pub exit_amount: Target,
     pub fee_amount: Target,
+}
+
+impl AmountsTargets {
+    pub fn new(builder: &mut CircuitBuilder<F, D>) -> Self {
+        Self {
+            funding_tx_amount: builder.add_virtual_public_input(),
+            exit_amount: builder.add_virtual_public_input(),
+            fee_amount: builder.add_virtual_public_input(),
+        }
+    }
 }
 
 impl CircuitFragment for Amounts {
@@ -74,23 +84,16 @@ impl CircuitFragment for Amounts {
     type Targets = AmountsTargets;
 
     /// Builds a circuit that asserts `funding_tx_amount = exit_amount + fee_amount`.
-    fn circuit(builder: &mut CircuitBuilder<F, D>) -> Self::Targets {
-        let funding_tx_amount = builder.add_virtual_target();
-        let exit_amount = builder.add_virtual_target();
-        let fee_amount = builder.add_virtual_target();
-
-        builder.register_public_input(funding_tx_amount);
-        builder.register_public_input(exit_amount);
-        builder.register_public_input(fee_amount);
-
-        let sum = builder.add(exit_amount, fee_amount);
-        builder.connect(sum, funding_tx_amount);
-
-        AmountsTargets {
+    fn circuit(
+        Self::Targets {
             funding_tx_amount,
             exit_amount,
             fee_amount,
-        }
+        }: Self::Targets,
+        builder: &mut CircuitBuilder<F, D>,
+    ) {
+        let sum = builder.add(exit_amount, fee_amount);
+        builder.connect(sum, funding_tx_amount);
     }
 
     fn fill_targets(
@@ -117,7 +120,8 @@ mod tests {
 
     fn run_test(amounts: &Amounts) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let (mut builder, mut pw) = setup_test_builder_and_witness();
-        let targets = Amounts::circuit(&mut builder);
+        let targets = AmountsTargets::new(&mut builder);
+        Amounts::circuit(targets, &mut builder);
 
         amounts.fill_targets(&mut pw, targets, ()).unwrap();
         build_and_prove_test(builder, pw)

--- a/circuit/src/amounts.rs
+++ b/circuit/src/amounts.rs
@@ -85,11 +85,11 @@ impl CircuitFragment for Amounts {
 
     /// Builds a circuit that asserts `funding_tx_amount = exit_amount + fee_amount`.
     fn circuit(
-        Self::Targets {
+        &Self::Targets {
             funding_tx_amount,
             exit_amount,
             fee_amount,
-        }: Self::Targets,
+        }: &Self::Targets,
         builder: &mut CircuitBuilder<F, D>,
     ) {
         let sum = builder.add(exit_amount, fee_amount);
@@ -121,7 +121,7 @@ mod tests {
     fn run_test(amounts: &Amounts) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let (mut builder, mut pw) = setup_test_builder_and_witness();
         let targets = AmountsTargets::new(&mut builder);
-        Amounts::circuit(targets, &mut builder);
+        Amounts::circuit(&targets, &mut builder);
 
         amounts.fill_targets(&mut pw, targets, ()).unwrap();
         build_and_prove_test(builder, pw)

--- a/circuit/src/circuit.rs
+++ b/circuit/src/circuit.rs
@@ -29,7 +29,7 @@ pub trait CircuitFragment {
     type Targets;
 
     /// Builds a circuit with the operating wires being provided by `Self::Targets`.
-    fn circuit(targets: Self::Targets, builder: &mut CircuitBuilder<F, D>);
+    fn circuit(targets: &Self::Targets, builder: &mut CircuitBuilder<F, D>);
 
     /// Fills the targets in the partial witness with the provided inputs.
     fn fill_targets(
@@ -105,16 +105,11 @@ impl Default for WormholeCircuit {
         let targets = CircuitTargets::new(&mut builder);
 
         // Setup circuits.
-        {
-            // Clone targets so we can pass them to the circuits but keep ownership within
-            // `WormholeCircuit`.
-            let targets = targets.clone();
-            Amounts::circuit(targets.amounts, &mut builder);
-            Nullifier::circuit(targets.nullifier, &mut builder);
-            UnspendableAccount::circuit(targets.unspendable_account, &mut builder);
-            StorageProof::circuit(targets.storage_proof, &mut builder);
-            ExitAccount::circuit(targets.exit_account, &mut builder);
-        }
+        Amounts::circuit(&targets.amounts, &mut builder);
+        Nullifier::circuit(&targets.nullifier, &mut builder);
+        UnspendableAccount::circuit(&targets.unspendable_account, &mut builder);
+        StorageProof::circuit(&targets.storage_proof, &mut builder);
+        ExitAccount::circuit(&targets.exit_account, &mut builder);
 
         Self { builder, targets }
     }

--- a/circuit/src/circuit.rs
+++ b/circuit/src/circuit.rs
@@ -25,7 +25,11 @@ pub type C = PoseidonGoldilocksConfig;
 pub type F = GoldilocksField;
 
 pub trait CircuitFragment {
+    /// Private inputs to the circuit. These are not stored within the circuit structs themselves
+    /// and thus needs to be supplied via this type.
     type PrivateInputs;
+    /// The targets that the circuit operates on. These are constrained in the circuit definition
+    /// and filled with [`Self::fill_targets`].
     type Targets;
 
     /// Builds a circuit with the operating wires being provided by `Self::Targets`.

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -73,7 +73,7 @@ impl CircuitFragment for ExitAccount {
     type Targets = ExitAccountTargets;
 
     /// Builds a dummy circuit to include the exit account as a public input.
-    fn circuit(Self::Targets { address: _ }: Self::Targets, _builder: &mut CircuitBuilder<F, D>) {}
+    fn circuit(Self::Targets { address: _ }: &Self::Targets, _builder: &mut CircuitBuilder<F, D>) {}
 
     fn fill_targets(
         &self,
@@ -99,7 +99,7 @@ mod tests {
     fn run_test(exit_account: &ExitAccount) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let (mut builder, mut pw) = setup_test_builder_and_witness();
         let targets = ExitAccountTargets::new(&mut builder);
-        ExitAccount::circuit(targets, &mut builder);
+        ExitAccount::circuit(&targets, &mut builder);
 
         exit_account.fill_targets(&mut pw, targets, ()).unwrap();
         build_and_prove_test(builder, pw)

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -60,15 +60,20 @@ pub struct ExitAccountTargets {
     pub address: HashOutTarget,
 }
 
+impl ExitAccountTargets {
+    pub fn new(builder: &mut CircuitBuilder<F, D>) -> Self {
+        Self {
+            address: builder.add_virtual_hash_public_input(),
+        }
+    }
+}
+
 impl CircuitFragment for ExitAccount {
     type PrivateInputs = ();
     type Targets = ExitAccountTargets;
 
     /// Builds a dummy circuit to include the exit account as a public input.
-    fn circuit(builder: &mut CircuitBuilder<F, D>) -> Self::Targets {
-        let address = builder.add_virtual_hash_public_input();
-        ExitAccountTargets { address }
-    }
+    fn circuit(Self::Targets { address: _ }: Self::Targets, _builder: &mut CircuitBuilder<F, D>) {}
 
     fn fill_targets(
         &self,
@@ -93,7 +98,8 @@ mod tests {
 
     fn run_test(exit_account: &ExitAccount) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let (mut builder, mut pw) = setup_test_builder_and_witness();
-        let targets = ExitAccount::circuit(&mut builder);
+        let targets = ExitAccountTargets::new(&mut builder);
+        ExitAccount::circuit(targets, &mut builder);
 
         exit_account.fill_targets(&mut pw, targets, ()).unwrap();
         build_and_prove_test(builder, pw)

--- a/circuit/src/nullifier.rs
+++ b/circuit/src/nullifier.rs
@@ -102,7 +102,7 @@ impl CircuitFragment for Nullifier {
     /// Builds a circuit that assert that nullifier was computed with `H(H(nullifier +
     /// extrinsic_index + secret))`
     fn circuit(
-        Self::Targets { hash, preimage }: Self::Targets,
+        &Self::Targets { hash, ref preimage }: &Self::Targets,
         builder: &mut CircuitBuilder<F, D>,
     ) {
         // Compute the `generated_account` by double-hashing the preimage (salt + secret).
@@ -167,7 +167,7 @@ pub mod tests {
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let (mut builder, mut pw) = setup_test_builder_and_witness();
         let targets = NullifierTargets::new(&mut builder);
-        Nullifier::circuit(targets.clone(), &mut builder);
+        Nullifier::circuit(&targets, &mut builder);
 
         nullifier.fill_targets(&mut pw, targets, inputs).unwrap();
         build_and_prove_test(builder, pw)

--- a/circuit/src/storage_proof.rs
+++ b/circuit/src/storage_proof.rs
@@ -100,12 +100,12 @@ impl CircuitFragment for StorageProof {
     type Targets = StorageProofTargets;
 
     fn circuit(
-        Self::Targets {
+        &Self::Targets {
             root_hash,
             proof_len,
-            proof_data,
-            hashes,
-        }: Self::Targets,
+            ref proof_data,
+            ref hashes,
+        }: &Self::Targets,
         builder: &mut CircuitBuilder<F, D>,
     ) {
         // Setup constraints.
@@ -227,7 +227,7 @@ pub mod tests {
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let (mut builder, mut pw) = setup_test_builder_and_witness();
         let targets = StorageProofTargets::new(&mut builder);
-        StorageProof::circuit(targets.clone(), &mut builder);
+        StorageProof::circuit(&targets, &mut builder);
 
         storage_proof
             .fill_targets(&mut pw, targets, inputs)

--- a/circuit/src/storage_proof.rs
+++ b/circuit/src/storage_proof.rs
@@ -234,7 +234,10 @@ pub mod tests {
     #[test]
     #[should_panic(expected = "set twice with different values")]
     fn invalid_root_hash_fails() {
-        let proof = StorageProof::default();
+        let proof = StorageProof {
+            root_hash: [0u8; 32],
+            ..Default::default()
+        };
         run_test(&proof).unwrap();
     }
 

--- a/circuit/src/unspendable_account.rs
+++ b/circuit/src/unspendable_account.rs
@@ -106,10 +106,10 @@ impl CircuitFragment for UnspendableAccount {
 
     /// Builds a circuit that asserts that the `unspendable_account` was generated from `H(H(salt+secret))`.
     fn circuit(
-        Self::Targets {
+        &Self::Targets {
             account_id,
-            preimage,
-        }: Self::Targets,
+            ref preimage,
+        }: &Self::Targets,
         builder: &mut CircuitBuilder<F, D>,
     ) {
         // Compute the `generated_account` by double-hashing the preimage (salt + secret).
@@ -195,7 +195,7 @@ pub mod tests {
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let (mut builder, mut pw) = setup_test_builder_and_witness();
         let targets = UnspendableAccountTargets::new(&mut builder);
-        UnspendableAccount::circuit(targets.clone(), &mut builder);
+        UnspendableAccount::circuit(&targets, &mut builder);
 
         unspendable_account
             .fill_targets(&mut pw, targets, inputs)

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -35,7 +35,7 @@ use wormhole_circuit::{
     exit_account::ExitAccount,
     inputs::CircuitInputs,
     nullifier::{Nullifier, NullifierInputs},
-    storage_proof::{StorageProof, StorageProofInputs},
+    storage_proof::StorageProof,
     unspendable_account::{UnspendableAccount, UnspendableAccountInputs},
 };
 
@@ -99,11 +99,7 @@ impl WormholeProver {
             targets.unspendable_account,
             unspendable_account_inputs,
         )?;
-        storage_proof.fill_targets(
-            &mut self.partial_witness,
-            targets.storage_proof,
-            StorageProofInputs::new(circuit_inputs.public.root_hash),
-        )?;
+        storage_proof.fill_targets(&mut self.partial_witness, targets.storage_proof, ())?;
         exit_account.fill_targets(&mut self.partial_witness, targets.exit_account, ())?;
 
         Ok(self)


### PR DESCRIPTION
Decouples the creation of circuit targets from the defining of constrains. This will allow us to define shared targets later down the line.