### PR TITLE
ref: remove private inputs type

### DIFF
--- a/circuit/src/amounts.rs
+++ b/circuit/src/amounts.rs
@@ -7,11 +7,8 @@ use plonky2::{
     plonk::circuit_builder::CircuitBuilder,
 };
 
+use crate::circuit::{CircuitFragment, D, F};
 use crate::inputs::CircuitInputs;
-use crate::{
-    circuit::{CircuitFragment, D, F},
-    codec::FieldElementCodec,
-};
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Amounts {
@@ -30,25 +27,6 @@ impl Amounts {
             exit_amount: F::from_noncanonical_u64(exit_amount),
             fee_amount: F::from_noncanonical_u64(fee_amount),
         }
-    }
-}
-
-impl FieldElementCodec for Amounts {
-    fn to_field_elements(&self) -> Vec<F> {
-        [self.funding_tx_amount, self.exit_amount, self.fee_amount].to_vec()
-    }
-
-    fn from_field_elements(elements: &[F]) -> anyhow::Result<Self> {
-        if elements.len() != 3 {
-            return Err(anyhow::anyhow!(
-                "Expected 3 field elements for ExitAccount address"
-            ));
-        }
-        Ok(Self {
-            funding_tx_amount: elements[0],
-            exit_amount: elements[1],
-            fee_amount: elements[2],
-        })
     }
 }
 
@@ -80,7 +58,6 @@ impl AmountsTargets {
 }
 
 impl CircuitFragment for Amounts {
-    type PrivateInputs = ();
     type Targets = AmountsTargets;
 
     /// Builds a circuit that asserts `funding_tx_amount = exit_amount + fee_amount`.
@@ -100,7 +77,6 @@ impl CircuitFragment for Amounts {
         &self,
         pw: &mut PartialWitness<F>,
         targets: Self::Targets,
-        _inputs: Self::PrivateInputs,
     ) -> anyhow::Result<()> {
         pw.set_target(targets.funding_tx_amount, self.funding_tx_amount)?;
         pw.set_target(targets.exit_amount, self.exit_amount)?;
@@ -123,7 +99,7 @@ mod tests {
         let targets = AmountsTargets::new(&mut builder);
         Amounts::circuit(&targets, &mut builder);
 
-        amounts.fill_targets(&mut pw, targets, ()).unwrap();
+        amounts.fill_targets(&mut pw, targets).unwrap();
         build_and_prove_test(builder, pw)
     }
 
@@ -176,67 +152,5 @@ mod tests {
         let amounts = Amounts::new(100, 10, 100);
         let result = run_test(&amounts);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn amounts_codec() {
-        let amounts = Amounts {
-            funding_tx_amount: F::from_noncanonical_u64(123),
-            exit_amount: F::from_noncanonical_u64(456),
-            fee_amount: F::from_noncanonical_u64(789),
-        };
-
-        let field_elements = amounts.to_field_elements();
-        assert_eq!(field_elements.len(), 3);
-        assert_eq!(
-            amounts,
-            Amounts::from_field_elements(&field_elements).unwrap()
-        );
-    }
-
-    #[test]
-    fn invalid_length() {
-        let short_elements = vec![F::from_noncanonical_u64(1), F::from_noncanonical_u64(2)];
-        assert!(Amounts::from_field_elements(&short_elements).is_err());
-
-        let long_elements = vec![
-            F::from_noncanonical_u64(1),
-            F::from_noncanonical_u64(2),
-            F::from_noncanonical_u64(3),
-            F::from_noncanonical_u64(4),
-        ];
-        assert!(Amounts::from_field_elements(&long_elements).is_err());
-    }
-
-    #[test]
-    fn empty_elements() {
-        let empty_elements: Vec<F> = vec![];
-        assert!(Amounts::from_field_elements(&empty_elements).is_err());
-    }
-
-    #[test]
-    fn zero_values() {
-        let zero_amounts = Amounts {
-            funding_tx_amount: F::from_noncanonical_u64(0),
-            exit_amount: F::from_noncanonical_u64(0),
-            fee_amount: F::from_noncanonical_u64(0),
-        };
-        assert_eq!(
-            zero_amounts,
-            Amounts::from_field_elements(&zero_amounts.to_field_elements()).unwrap()
-        );
-    }
-
-    #[test]
-    fn different_values() {
-        let different_amounts = Amounts {
-            funding_tx_amount: F::from_noncanonical_u64(987),
-            exit_amount: F::from_noncanonical_u64(654),
-            fee_amount: F::from_noncanonical_u64(321),
-        };
-        assert_eq!(
-            different_amounts,
-            Amounts::from_field_elements(&different_amounts.to_field_elements()).unwrap()
-        );
     }
 }

--- a/circuit/src/circuit.rs
+++ b/circuit/src/circuit.rs
@@ -24,7 +24,7 @@ pub type F = GoldilocksField;
 
 pub trait CircuitFragment {
     /// The targets that the circuit operates on. These are constrained in the circuit definition
-    /// and filled with [`Self::fill_targets]`.
+    /// and filled with [`Self::fill_targets`].
     type Targets;
 
     /// Builds a circuit with the operating wires being provided by `Self::Targets`.

--- a/circuit/src/codec.rs
+++ b/circuit/src/codec.rs
@@ -1,11 +1,11 @@
 use crate::circuit::F;
 
-pub trait FieldElementCodec: Sized {
+pub trait FieldElementCodec<const SIZE: usize>: Sized {
     fn to_field_elements(&self) -> Vec<F>;
-    fn from_field_elements(elements: &[F]) -> anyhow::Result<Self>;
+    fn from_field_elements(elements: [F; SIZE]) -> Self;
 }
 
-pub trait ByteCodec: Sized {
+pub trait ByteCodec<const SIZE: usize>: Sized {
     fn to_bytes(&self) -> Vec<u8>;
-    fn from_bytes(slice: &[u8]) -> anyhow::Result<Self>;
+    fn from_bytes(slice: [u8; SIZE]) -> Self;
 }

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -1,6 +1,8 @@
-use crate::circuit::{CircuitFragment, FieldHash, D, F, HASH_NUM_FELTS};
-use crate::codec::{ByteCodec, FieldElementCodec};
+use crate::circuit::{CircuitFragment, D};
+use crate::codec::ByteCodec;
 use crate::inputs::CircuitInputs;
+use crate::util::{FieldHash, HASH_NUM_FELTS};
+use crate::{circuit::F, codec::FieldElementCodec};
 use plonky2::{
     hash::hash_types::HashOutTarget,
     iop::witness::{PartialWitness, WitnessWrite},
@@ -23,7 +25,7 @@ impl From<&CircuitInputs> for ExitAccount {
     }
 }
 
-impl FieldElementCodec<HASH_NUM_FELTS> for ExitAccount {
+impl FieldElementCodec<{ HASH_NUM_FELTS }> for ExitAccount {
     fn to_field_elements(&self) -> Vec<F> {
         self.0.to_vec()
     }

--- a/circuit/src/exit_account.rs
+++ b/circuit/src/exit_account.rs
@@ -1,6 +1,4 @@
-use crate::circuit::{
-    field_elements_to_bytes, slice_to_field_elements, CircuitFragment, Digest, D, F,
-};
+use crate::circuit::{CircuitFragment, FieldHash, D, F, HASH_NUM_FELTS};
 use crate::codec::{ByteCodec, FieldElementCodec};
 use crate::inputs::CircuitInputs;
 use plonky2::{
@@ -10,48 +8,28 @@ use plonky2::{
 };
 
 #[derive(Debug, Default, Eq, PartialEq, Clone, Copy)]
-pub struct ExitAccount(Digest);
+pub struct ExitAccount(FieldHash);
 
 impl ExitAccount {
-    pub fn new(address: &[u8]) -> anyhow::Result<Self> {
-        Self::from_bytes(address)
-    }
-}
-
-impl ByteCodec for ExitAccount {
-    fn to_bytes(&self) -> Vec<u8> {
-        field_elements_to_bytes(&self.0)
-    }
-
-    fn from_bytes(slice: &[u8]) -> anyhow::Result<Self> {
-        let address = slice_to_field_elements(slice).try_into().map_err(|_| {
-            anyhow::anyhow!("failed to deserialize bytes into exit account address")
-        })?;
-        Ok(ExitAccount(address))
-    }
-}
-
-impl FieldElementCodec for ExitAccount {
-    fn to_field_elements(&self) -> Vec<F> {
-        self.0.to_vec()
-    }
-
-    fn from_field_elements(elements: &[F]) -> anyhow::Result<Self> {
-        if elements.len() != 4 {
-            return Err(anyhow::anyhow!(
-                "Expected 4 field elements for ExitAccount address, got: {}",
-                elements.len()
-            ));
-        }
-
-        let address = elements.try_into()?;
-        Ok(Self(address))
+    pub fn new(address: [u8; 32]) -> Self {
+        let address = FieldHash::from_bytes(address);
+        Self(address)
     }
 }
 
 impl From<&CircuitInputs> for ExitAccount {
     fn from(inputs: &CircuitInputs) -> Self {
-        inputs.public.exit_account
+        Self::new(inputs.public.exit_account)
+    }
+}
+
+impl FieldElementCodec<HASH_NUM_FELTS> for ExitAccount {
+    fn to_field_elements(&self) -> Vec<F> {
+        self.0.to_vec()
+    }
+
+    fn from_field_elements(elements: [F; HASH_NUM_FELTS]) -> Self {
+        Self(FieldHash(elements))
     }
 }
 
@@ -69,7 +47,6 @@ impl ExitAccountTargets {
 }
 
 impl CircuitFragment for ExitAccount {
-    type PrivateInputs = ();
     type Targets = ExitAccountTargets;
 
     /// Builds a dummy circuit to include the exit account as a public input.
@@ -79,9 +56,9 @@ impl CircuitFragment for ExitAccount {
         &self,
         pw: &mut PartialWitness<F>,
         targets: Self::Targets,
-        _inputs: Self::PrivateInputs,
     ) -> anyhow::Result<()> {
-        pw.set_hash_target(targets.address, self.0.into())
+        let hash = *self.0;
+        pw.set_hash_target(targets.address, hash.into())
     }
 }
 
@@ -101,7 +78,7 @@ mod tests {
         let targets = ExitAccountTargets::new(&mut builder);
         ExitAccount::circuit(&targets, &mut builder);
 
-        exit_account.fill_targets(&mut pw, targets, ()).unwrap();
+        exit_account.fill_targets(&mut pw, targets).unwrap();
         build_and_prove_test(builder, pw)
     }
 
@@ -113,17 +90,18 @@ mod tests {
 
     #[test]
     fn test_exit_account_round_trip() -> anyhow::Result<()> {
-        let exit_account = ExitAccount::new(&[42u8; 32])?;
+        let exit_account = ExitAccount::new([42u8; 32]);
         let elements = exit_account.to_field_elements();
         assert_eq!(elements.len(), 4, "Expected 4 field elements");
-        let decoded = ExitAccount::from_field_elements(&elements)?;
+        let elements_array = elements.try_into().unwrap();
+        let decoded = ExitAccount::from_field_elements(elements_array);
         assert_eq!(exit_account, decoded, "Round-trip failed");
         Ok(())
     }
 
     #[test]
     fn test_exit_account_zero_address() -> anyhow::Result<()> {
-        let exit_account = ExitAccount::new(&[0u8; 32])?;
+        let exit_account = ExitAccount::new([0u8; 32]);
         let elements = exit_account.to_field_elements();
         assert_eq!(elements.len(), 4, "Expected 4 field elements");
         assert_eq!(
@@ -131,14 +109,15 @@ mod tests {
             vec![F::ZERO; 4],
             "Zero address should encode to zero elements"
         );
-        let decoded = ExitAccount::from_field_elements(&elements)?;
+        let elements_array = elements.try_into().unwrap();
+        let decoded = ExitAccount::from_field_elements(elements_array);
         assert_eq!(exit_account, decoded, "Zero address round-trip failed");
         Ok(())
     }
 
     #[test]
     fn test_exit_account_max_address() -> anyhow::Result<()> {
-        let exit_account = ExitAccount::new(&[255u8; 32])?;
+        let exit_account = ExitAccount::new([255u8; 32]);
         let elements = exit_account.to_field_elements();
         assert_eq!(elements.len(), 4, "Expected 4 field elements");
         // Each element should be u64::MAX (0xFFFFFFFFFFFFFFFF)
@@ -148,23 +127,10 @@ mod tests {
             vec![expected_value; 4],
             "Max address encoding incorrect"
         );
-        let decoded = ExitAccount::from_field_elements(&elements)?;
+        let elements_array = elements.try_into().unwrap();
+        let decoded = ExitAccount::from_field_elements(elements_array);
         assert_eq!(exit_account, decoded, "Max address round-trip failed");
         Ok(())
-    }
-
-    #[test]
-    fn test_exit_account_insufficient_elements() {
-        let elements = vec![F::ZERO; 3]; // Too few elements
-        let result = ExitAccount::from_field_elements(&elements);
-        assert!(
-            result.is_err(),
-            "Decoding with insufficient elements should fail"
-        );
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "Expected 4 field elements for ExitAccount address, got: 3"
-        );
     }
 
     #[test]
@@ -172,7 +138,7 @@ mod tests {
         let mut address = [0u8; 32];
         address[0] = 1;
         address[31] = 255; // Non-zero first and last bytes
-        let exit_account = ExitAccount::new(&address)?;
+        let exit_account = ExitAccount::new(address);
         let elements = exit_account.to_field_elements();
         assert_eq!(elements.len(), 4, "Expected 4 field elements");
         // First element: 0x0000000000000001 (little-endian)
@@ -181,101 +147,9 @@ mod tests {
         let expected_last = F::from_canonical_u64((255u64 << 56) % F::ORDER);
         assert_eq!(elements[0], expected_first, "First element incorrect");
         assert_eq!(elements[3], expected_last, "Last element incorrect");
-        let decoded = ExitAccount::from_field_elements(&elements)?;
+        let elements_array = elements.try_into().unwrap();
+        let decoded = ExitAccount::from_field_elements(elements_array);
         assert_eq!(exit_account, decoded, "Specific address round-trip failed");
         Ok(())
-    }
-
-    #[test]
-    fn exit_account_codec() {
-        let address_bytes = [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 32,
-        ];
-        let account = ExitAccount::new(&address_bytes).unwrap();
-
-        // Encode the account's address into field elements.
-        let field_elements = account.to_field_elements();
-        assert_eq!(field_elements.len(), 4);
-
-        // Reconstruct the original bytes from the field elements.
-        let mut expected_elements = Vec::new();
-        for i in 0..4 {
-            let mut bytes = [0u8; 8];
-            bytes.copy_from_slice(&address_bytes[i * 8..(i + 1) * 8]);
-            let value = u64::from_le_bytes(bytes);
-            expected_elements.push(F::from_noncanonical_u64(value));
-        }
-        assert_eq!(field_elements, expected_elements);
-
-        // Decode the field elements back into an ExitAccount.
-        let recovered_account = ExitAccount::from_field_elements(&field_elements).unwrap();
-        assert_eq!(account, recovered_account);
-    }
-
-    #[test]
-    fn codec_invalid_length() {
-        let short_elements = vec![F::from_noncanonical_u64(1), F::from_noncanonical_u64(2)];
-        let recovered_account_result = ExitAccount::from_field_elements(&short_elements);
-
-        assert!(recovered_account_result.is_err());
-        assert_eq!(
-            recovered_account_result.unwrap_err().to_string(),
-            "Expected 4 field elements for ExitAccount address, got: 2"
-        );
-
-        let long_elements = vec![
-            F::from_noncanonical_u64(1),
-            F::from_noncanonical_u64(2),
-            F::from_noncanonical_u64(3),
-            F::from_noncanonical_u64(4),
-            F::from_noncanonical_u64(5),
-        ];
-
-        let recovered_account_result = ExitAccount::from_field_elements(&long_elements);
-        assert!(recovered_account_result.is_err());
-        assert_eq!(
-            recovered_account_result.unwrap_err().to_string(),
-            "Expected 4 field elements for ExitAccount address, got: 5"
-        );
-    }
-
-    #[test]
-    fn codec_empty_elements() {
-        let empty_elements: Vec<F> = vec![];
-        let recovered_account_result = ExitAccount::from_field_elements(&empty_elements);
-        assert!(recovered_account_result.is_err());
-        assert_eq!(
-            recovered_account_result.unwrap_err().to_string(),
-            "Expected 4 field elements for ExitAccount address, got: 0"
-        );
-    }
-
-    #[test]
-    fn codec_different_byte_patterns() {
-        // Test with all zeros.
-        let zero_address = [0u8; 32];
-        let account_zero = ExitAccount::new(&zero_address).unwrap();
-        let field_elements_zero = account_zero.to_field_elements();
-        let recovered_zero = ExitAccount::from_field_elements(&field_elements_zero).unwrap();
-        assert_eq!(account_zero, recovered_zero);
-
-        // Test with all ones.
-        let one_address = [1u8; 32];
-        let account_one = ExitAccount::new(&one_address).unwrap();
-        let field_elements_one = account_one.to_field_elements();
-        let recovered_one = ExitAccount::from_field_elements(&field_elements_one).unwrap();
-        assert_eq!(account_one, recovered_one);
-
-        // Test with a more varied pattern.
-        let varied_address = [
-            0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
-            0x10, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE, 0x21, 0x43, 0x65, 0x87, 0xA9, 0xCB,
-            0xE1, 0xF0, 0x34, 0x56,
-        ];
-        let account_varied = ExitAccount::new(&varied_address).unwrap();
-        let field_elements_varied = account_varied.to_field_elements();
-        let recovered_varied = ExitAccount::from_field_elements(&field_elements_varied).unwrap();
-        assert_eq!(account_varied, recovered_varied);
     }
 }

--- a/circuit/src/inputs.rs
+++ b/circuit/src/inputs.rs
@@ -1,7 +1,10 @@
 use anyhow::bail;
 use plonky2::{field::types::PrimeField64, plonk::proof::ProofWithPublicInputs};
 
-use crate::circuit::{field_elements_to_bytes, C, D, F};
+use crate::{
+    circuit::{C, D, F},
+    util::field_elements_to_bytes,
+};
 
 const PUBLIC_INPUTS_FELTS_LEN: usize = 19;
 

--- a/circuit/src/lib.rs
+++ b/circuit/src/lib.rs
@@ -7,3 +7,4 @@ pub mod inputs;
 pub mod nullifier;
 pub mod storage_proof;
 pub mod unspendable_account;
+pub mod util;

--- a/circuit/src/nullifier.rs
+++ b/circuit/src/nullifier.rs
@@ -29,7 +29,7 @@ impl Nullifier {
         Self { hash, preimage }
     }
 
-    /// Cosntructs a new [`Nullfierie`] from just the preimage.
+    /// Cosntructs a new [`Nullifier`] from just the preimage.
     pub fn from_preimage(preimage: &[u8]) -> Self {
         // First, convert the preimage to its representation as field elements.
         let preimage = slice_to_field_elements(preimage);

--- a/circuit/src/nullifier.rs
+++ b/circuit/src/nullifier.rs
@@ -7,8 +7,12 @@ use plonky2::{
     plonk::{circuit_builder::CircuitBuilder, config::Hasher},
 };
 
-use crate::circuit::{slice_to_field_elements, CircuitFragment, FieldHash, D, F};
-use crate::{codec::ByteCodec, inputs::CircuitInputs};
+use crate::{
+    circuit::{CircuitFragment, D, F},
+    codec::ByteCodec,
+    inputs::CircuitInputs,
+    util::{slice_to_field_elements, FieldHash},
+};
 
 // FIXME: Adjust as needed.
 pub const PREIMAGE_NUM_TARGETS: usize = 5;

--- a/circuit/src/storage_proof.rs
+++ b/circuit/src/storage_proof.rs
@@ -8,9 +8,12 @@ use plonky2::{
     plonk::circuit_builder::CircuitBuilder,
 };
 
-use crate::circuit::{slice_to_field_elements, CircuitFragment, D, F};
 use crate::gadgets::is_const_less_than;
 use crate::inputs::CircuitInputs;
+use crate::{
+    circuit::{CircuitFragment, D, F},
+    util::slice_to_field_elements,
+};
 
 pub const MAX_PROOF_LEN: usize = 64;
 pub const PROOF_NODE_MAX_SIZE_F: usize = 73;

--- a/circuit/src/storage_proof.rs
+++ b/circuit/src/storage_proof.rs
@@ -87,7 +87,6 @@ impl From<&CircuitInputs> for StorageProof {
 }
 
 impl CircuitFragment for StorageProof {
-    type PrivateInputs = ();
     type Targets = StorageProofTargets;
 
     fn circuit(
@@ -125,7 +124,6 @@ impl CircuitFragment for StorageProof {
         &self,
         pw: &mut plonky2::iop::witness::PartialWitness<F>,
         targets: Self::Targets,
-        _inputs: Self::PrivateInputs,
     ) -> anyhow::Result<()> {
         const EMPTY_PROOF_NODE: [F; PROOF_NODE_MAX_SIZE_F] = [F::ZERO; PROOF_NODE_MAX_SIZE_F];
 
@@ -221,7 +219,7 @@ pub mod tests {
         let targets = StorageProofTargets::new(&mut builder);
         StorageProof::circuit(&targets, &mut builder);
 
-        storage_proof.fill_targets(&mut pw, targets, ()).unwrap();
+        storage_proof.fill_targets(&mut pw, targets).unwrap();
         build_and_prove_test(builder, pw)
     }
 

--- a/circuit/src/unspendable_account.rs
+++ b/circuit/src/unspendable_account.rs
@@ -7,10 +7,11 @@ use plonky2::{
     plonk::{circuit_builder::CircuitBuilder, config::Hasher},
 };
 
-use crate::inputs::CircuitInputs;
 use crate::{
-    circuit::{slice_to_field_elements, CircuitFragment, FieldHash, D, F},
+    circuit::{CircuitFragment, D, F},
     codec::ByteCodec,
+    inputs::CircuitInputs,
+    util::{slice_to_field_elements, FieldHash},
 };
 
 // FIXME: Adjust as needed.
@@ -142,9 +143,12 @@ pub mod test_helpers {
 pub mod tests {
     use plonky2::{field::types::Field, plonk::proof::ProofWithPublicInputs};
 
-    use crate::circuit::{
-        tests::{build_and_prove_test, setup_test_builder_and_witness},
-        C, HASH_NUM_FELTS,
+    use crate::{
+        circuit::{
+            tests::{build_and_prove_test, setup_test_builder_and_witness},
+            C,
+        },
+        util::HASH_NUM_FELTS,
     };
 
     use super::{

--- a/circuit/src/util.rs
+++ b/circuit/src/util.rs
@@ -1,0 +1,84 @@
+//! Utility.
+//!
+//! This module defines utility functions and constants used across the crate.
+use std::ops::Deref;
+
+use plonky2::field::types::{Field, PrimeField64};
+
+use crate::{
+    circuit::F,
+    codec::{ByteCodec, FieldElementCodec},
+};
+
+pub type Digest = [F; 4];
+
+pub const BYTES_PER_FELT: usize = 8;
+pub const HASH_NUM_FELTS: usize = 4;
+
+/// A hash that stores the underlying data as field elments.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub struct FieldHash(pub Digest);
+
+impl Deref for FieldHash {
+    type Target = Digest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Digest> for FieldHash {
+    fn from(digest: Digest) -> Self {
+        Self(digest)
+    }
+}
+
+impl ByteCodec<{ HASH_NUM_FELTS * BYTES_PER_FELT }> for FieldHash {
+    fn to_bytes(&self) -> Vec<u8> {
+        field_elements_to_bytes(&self.0)
+    }
+
+    fn from_bytes(bytes: [u8; HASH_NUM_FELTS * BYTES_PER_FELT]) -> Self {
+        // TODO: look at this, can it be better? no unwrapping?
+        let felts = slice_to_field_elements(&bytes).try_into().unwrap();
+        Self(felts)
+    }
+}
+
+impl FieldElementCodec<4> for FieldHash {
+    fn to_field_elements(&self) -> Vec<F> {
+        self.0.to_vec()
+    }
+
+    fn from_field_elements(elements: [F; 4]) -> Self {
+        Self(elements)
+    }
+}
+
+/// Converts a given slice into its field element representation.
+pub fn slice_to_field_elements(input: &[u8]) -> Vec<F> {
+    let mut field_elements: Vec<F> = Vec::new();
+    for chunk in input.chunks(BYTES_PER_FELT) {
+        let mut bytes = [0u8; 8];
+        bytes[..chunk.len()].copy_from_slice(chunk);
+        // Convert the chunk to a field element.
+        let value = u64::from_le_bytes(bytes);
+        let field_element = F::from_noncanonical_u64(value);
+        field_elements.push(field_element);
+    }
+
+    field_elements
+}
+
+/// Converts a given field element slice into its byte representation.
+pub fn field_elements_to_bytes(input: &[F]) -> Vec<u8> {
+    let mut bytes: Vec<u8> = Vec::new();
+
+    for field_element in input {
+        let value = field_element.to_noncanonical_u64();
+        let value_bytes = value.to_le_bytes();
+        bytes.extend_from_slice(&value_bytes);
+    }
+
+    bytes
+}

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -34,9 +34,9 @@ use wormhole_circuit::{
     circuit::{CircuitFragment, CircuitTargets},
     exit_account::ExitAccount,
     inputs::CircuitInputs,
-    nullifier::{Nullifier, NullifierInputs},
+    nullifier::Nullifier,
     storage_proof::StorageProof,
-    unspendable_account::{UnspendableAccount, UnspendableAccountInputs},
+    unspendable_account::UnspendableAccount,
 };
 
 #[derive(Debug)]
@@ -84,23 +84,11 @@ impl WormholeProver {
         let storage_proof = StorageProof::from(circuit_inputs);
         let exit_account = ExitAccount::from(circuit_inputs);
 
-        let nullifier_inputs = NullifierInputs::new(&circuit_inputs.private.nullifier_preimage);
-        let unspendable_account_inputs =
-            UnspendableAccountInputs::new(&circuit_inputs.private.unspendable_account_preimage);
-
-        amounts.fill_targets(&mut self.partial_witness, targets.amounts, ())?;
-        nullifier.fill_targets(
-            &mut self.partial_witness,
-            targets.nullifier,
-            nullifier_inputs,
-        )?;
-        unspendable_account.fill_targets(
-            &mut self.partial_witness,
-            targets.unspendable_account,
-            unspendable_account_inputs,
-        )?;
-        storage_proof.fill_targets(&mut self.partial_witness, targets.storage_proof, ())?;
-        exit_account.fill_targets(&mut self.partial_witness, targets.exit_account, ())?;
+        amounts.fill_targets(&mut self.partial_witness, targets.amounts)?;
+        nullifier.fill_targets(&mut self.partial_witness, targets.nullifier)?;
+        unspendable_account.fill_targets(&mut self.partial_witness, targets.unspendable_account)?;
+        storage_proof.fill_targets(&mut self.partial_witness, targets.storage_proof)?;
+        exit_account.fill_targets(&mut self.partial_witness, targets.exit_account)?;
 
         Ok(self)
     }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -78,9 +78,9 @@ mod tests {
         let mut proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
         println!("proof before: {:?}", proof.public_inputs);
-        let exit_account = ExitAccount::from_field_elements(&proof.public_inputs[15..19]);
+        let exit_account = &proof.public_inputs[15..19];
         println!("exit_account: {:?}", exit_account);
-        let modified_exit_account = ExitAccount::new(&[8u8; 32]).unwrap();
+        let modified_exit_account = ExitAccount::new([8u8; 32]);
         proof.public_inputs[15..19].copy_from_slice(&modified_exit_account.to_field_elements());
         println!("proof after: {:?}", proof.public_inputs);
 


### PR DESCRIPTION
- Refactors the `CircuitTrait` further, removing the previous `PrivateInputs` type that defined external inputs to the circuit. All inputs are instead stored directly within the defining structs.
- Adds a new `src/util.rs` to the circuit for encapsulating some common and shared functionality we had across the crate.