### PR TITLE
ci: run tests under release profile

### DIFF
--- a/.github/workflows/basics.yaml
+++ b/.github/workflows/basics.yaml
@@ -24,7 +24,7 @@ jobs:
             run: cargo build --release
 
           - name: Run tests
-            run: cargo test --all-features
+            run: cargo test --release --all-features
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Tests have started to take too long running under the debug profile. This PR runs the tests under the release profile instead trading some compile time for faster testing.