### PR TITLE
ci: run clippy on all targets

### DIFF
--- a/.github/workflows/basics.yaml
+++ b/.github/workflows/basics.yaml
@@ -18,7 +18,7 @@ jobs:
             run: cargo fmt --check
 
           - name: Clippy lints
-            run: cargo clippy --workspace --all-features -- -D warnings
+            run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
           - name: Build project
             run: cargo build --release

--- a/tests/src/aggregator/circuit_tests.rs
+++ b/tests/src/aggregator/circuit_tests.rs
@@ -35,8 +35,6 @@ fn build_and_verify_proof() {
         let proof = prover.commit(&inputs).unwrap().prove().unwrap();
         proofs.push(proof);
     }
-
-    let num_proofs = proofs.len();
     run_test().unwrap();
 }
 
@@ -61,7 +59,6 @@ fn few_proofs_pass() {
     }
 
     // Get the number of valid proofs before appending the dummy proofs.
-    let num_proofs = proofs.len();
     proofs.extend_from_slice(&dummy_proofs);
 
     run_test().unwrap();

--- a/tests/src/circuit/utils_tests.rs
+++ b/tests/src/circuit/utils_tests.rs
@@ -28,7 +28,7 @@ fn test_u128_to_felts_to_u128_round_trip() {
         assert_eq!(felts.len(), 2, "Expected exactly two field elements");
 
         // Vec<F> -> u128
-        let round_trip_num = felts_to_u128(felts.clone());
+        let round_trip_num = felts_to_u128(felts);
 
         // Check that the high and low parts match
         let expected_high = (num >> 64) as u64;


### PR DESCRIPTION
Some lints under the test crate were missed because of this.

- Enables `--all-targets` flag in the CI.
- Fixes clippy lints that were overlooked.