### PR TITLE
feat: aggregator abstraction

### DIFF
--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -12,9 +12,11 @@ plonky2 = { workspace = true, default-features = false }
 wormhole-circuit = { path = "../circuit", default-features = false }
 wormhole-prover = { path = "../prover", default-features = false }
 wormhole-verifier = { path = "../verifier", default-features = false }
-hashbrown = "0.14.5"
-
-[dev-dependencies]
+# This is the same crate as used in plonky2. Need to have it for dummy proofs to work correctly.
+hashbrown = { version = "0.14.3", default-features = false, features = [
+  "ahash",
+  "serde",
+] }
 
 [features]
 default = ["std"]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -9,14 +9,10 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 plonky2 = { workspace = true, default-features = false }
+hashbrown = { version = "0.14.5", default-features = false }
 wormhole-circuit = { path = "../circuit", default-features = false }
 wormhole-prover = { path = "../prover", default-features = false }
 wormhole-verifier = { path = "../verifier", default-features = false }
-# This is the same crate as used in plonky2. Need to have it for dummy proofs to work correctly.
-hashbrown = { version = "0.14.3", default-features = false, features = [
-  "ahash",
-  "serde",
-] }
 
 [features]
 default = ["std"]

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1,0 +1,159 @@
+use anyhow::bail;
+use plonky2::{
+    iop::witness::PartialWitness,
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitConfig, CircuitData},
+    },
+};
+use wormhole_circuit::circuit::{CircuitFragment, C, D, F};
+use wormhole_verifier::ProofWithPublicInputs;
+
+use crate::{
+    circuit::{WormholeProofAggregatorInner, WormholeProofAggregatorTargets},
+    MAX_NUM_PROOFS_TO_AGGREGATE,
+};
+
+/// A circuit that aggregates proofs from the Wormhole circuit.
+pub struct WormholeProofAggregator {
+    inner: WormholeProofAggregatorInner,
+    circuit_data: CircuitData<F, C, D>,
+    partial_witness: PartialWitness<F>,
+    targets: WormholeProofAggregatorTargets,
+    proofs_buffer: Option<Vec<ProofWithPublicInputs<F, C, D>>>,
+}
+
+impl Default for WormholeProofAggregator {
+    fn default() -> Self {
+        let config = CircuitConfig::standard_recursion_zk_config();
+        Self::new(config)
+    }
+}
+
+impl WormholeProofAggregator {
+    pub fn new(config: CircuitConfig) -> Self {
+        let inner = WormholeProofAggregatorInner::new(config.clone());
+        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+
+        // Setup targets.
+        let targets = WormholeProofAggregatorTargets::new(&mut builder, config);
+
+        // Setup circuits.
+        WormholeProofAggregatorInner::circuit(&targets, &mut builder);
+        let circuit_data = builder.build();
+        let partial_witness = PartialWitness::new();
+        let proofs_buffer = Some(Vec::with_capacity(MAX_NUM_PROOFS_TO_AGGREGATE));
+
+        Self {
+            inner,
+            circuit_data,
+            partial_witness,
+            targets,
+            proofs_buffer,
+        }
+    }
+
+    pub fn push_proof(&mut self, proof: ProofWithPublicInputs<F, C, D>) -> anyhow::Result<()> {
+        if let Some(proofs_buffer) = self.proofs_buffer.as_mut() {
+            if proofs_buffer.len() >= MAX_NUM_PROOFS_TO_AGGREGATE {
+                bail!("tried to add proof when proof buffer is full")
+            }
+            proofs_buffer.push(proof);
+        } else {
+            self.proofs_buffer = Some(vec![proof]);
+        }
+
+        Ok(())
+    }
+
+    pub fn aggregate(&mut self) -> anyhow::Result<()> {
+        let Some(mut proofs) = self.proofs_buffer.take() else {
+            bail!("there are no proofs to aggregate")
+        };
+
+        let num_proofs = proofs.len();
+
+        // TODO: Perhaps this should be done in `fill_targets` instead.
+        // Fill the rest of the buffer with dummy proofs.
+        while proofs.len() < MAX_NUM_PROOFS_TO_AGGREGATE {
+            let dummy_proof = self.inner.dummy_proof()?;
+            proofs.push(dummy_proof);
+        }
+
+        let inputs = WormholeProofAggregatorInputs { proofs, num_proofs };
+
+        self.inner
+            .fill_targets(&mut self.partial_witness, self.targets.clone(), inputs)?;
+
+        Ok(())
+    }
+
+    /// Prove the circuit with commited values. It's necessary to call [`WormholeProofAggregator::aggregate`]
+    /// before running this function.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the prover has not commited to any inputs.
+    pub fn prove(self) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
+        self.circuit_data.prove(self.partial_witness)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wormhole_circuit::inputs::CircuitInputs;
+    use wormhole_prover::WormholeProver;
+
+    use super::*;
+
+    const CIRCUIT_CONFIG: CircuitConfig = CircuitConfig::standard_recursion_config();
+
+    #[test]
+    fn push_proof_to_buffer() {
+        // Create a proof.
+        let prover = WormholeProver::new(CIRCUIT_CONFIG);
+        let inputs = CircuitInputs::test_inputs();
+        let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+
+        let mut aggregator = WormholeProofAggregator::new(CIRCUIT_CONFIG);
+        aggregator.push_proof(proof).unwrap();
+
+        let proofs_buffer = aggregator.proofs_buffer.unwrap();
+        assert_eq!(proofs_buffer.len(), 1);
+    }
+
+    #[test]
+    fn push_proof_to_full_buffer() {
+        // Create a proof.
+        let prover = WormholeProver::new(CIRCUIT_CONFIG);
+        let inputs = CircuitInputs::test_inputs();
+        let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+
+        let mut aggregator = WormholeProofAggregator::new(CIRCUIT_CONFIG);
+
+        // Fill up the proof buffer.
+        for _ in 0..MAX_NUM_PROOFS_TO_AGGREGATE {
+            aggregator.push_proof(proof.clone()).unwrap();
+        }
+
+        let result = aggregator.push_proof(proof.clone());
+        assert!(result.is_err());
+
+        let proofs_buffer = aggregator.proofs_buffer.unwrap();
+        assert_eq!(proofs_buffer.len(), MAX_NUM_PROOFS_TO_AGGREGATE);
+    }
+
+    #[test]
+    fn aggregate_single_proof() {
+        // Create a proof.
+        let prover = WormholeProver::new(CIRCUIT_CONFIG);
+        let inputs = CircuitInputs::test_inputs();
+        let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+
+        let mut aggregator = WormholeProofAggregator::new(CIRCUIT_CONFIG);
+        aggregator.push_proof(proof).unwrap();
+
+        aggregator.aggregate().unwrap();
+        aggregator.prove().unwrap();
+    }
+}

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod aggregator;
 pub mod circuit;
 
 /// The maximum numbers of proofs to aggregate into a composite proof.

--- a/tests/src/aggregator/aggregator_tests.rs
+++ b/tests/src/aggregator/aggregator_tests.rs
@@ -1,0 +1,61 @@
+#![cfg(test)]
+use plonky2::plonk::circuit_data::CircuitConfig;
+use wormhole_aggregator::{aggregator::WormholeProofAggregator, MAX_NUM_PROOFS_TO_AGGREGATE};
+use wormhole_circuit::inputs::CircuitInputs;
+use wormhole_prover::WormholeProver;
+
+use crate::test_helpers::storage_proof::TestInputs;
+
+const CIRCUIT_CONFIG: CircuitConfig = CircuitConfig::standard_recursion_config();
+
+#[test]
+#[ignore = "takes too long"]
+fn push_proof_to_buffer() {
+    // Create a proof.
+    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let inputs = CircuitInputs::test_inputs();
+    let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+
+    let mut aggregator = WormholeProofAggregator::new(CIRCUIT_CONFIG);
+    aggregator.push_proof(proof).unwrap();
+
+    let proofs_buffer = aggregator.proofs_buffer.unwrap();
+    assert_eq!(proofs_buffer.len(), 1);
+}
+
+#[test]
+#[ignore = "takes too long"]
+fn push_proof_to_full_buffer() {
+    // Create a proof.
+    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let inputs = CircuitInputs::test_inputs();
+    let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+
+    let mut aggregator = WormholeProofAggregator::new(CIRCUIT_CONFIG);
+
+    // Fill up the proof buffer.
+    for _ in 0..MAX_NUM_PROOFS_TO_AGGREGATE {
+        aggregator.push_proof(proof.clone()).unwrap();
+    }
+
+    let result = aggregator.push_proof(proof.clone());
+    assert!(result.is_err());
+
+    let proofs_buffer = aggregator.proofs_buffer.unwrap();
+    assert_eq!(proofs_buffer.len(), MAX_NUM_PROOFS_TO_AGGREGATE);
+}
+
+#[test]
+#[ignore = "takes too long"]
+fn aggregate_single_proof() {
+    // Create a proof.
+    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let inputs = CircuitInputs::test_inputs();
+    let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+
+    let mut aggregator = WormholeProofAggregator::new(CIRCUIT_CONFIG);
+    aggregator.push_proof(proof).unwrap();
+
+    aggregator.aggregate().unwrap();
+    aggregator.prove().unwrap();
+}

--- a/tests/src/aggregator/circuit_tests.rs
+++ b/tests/src/aggregator/circuit_tests.rs
@@ -3,7 +3,7 @@ use crate::test_helpers::storage_proof::TestInputs;
 use hashbrown::HashMap;
 use plonky2::plonk::circuit_data::CircuitConfig;
 use plonky2::recursion::dummy_circuit::{dummy_circuit, dummy_proof};
-use wormhole_aggregator::circuit::{WormholeProofAggregator, WormholeProofAggregatorTargets};
+use wormhole_aggregator::circuit::{WormholeProofAggregatorInner, WormholeProofAggregatorTargets};
 use wormhole_aggregator::MAX_NUM_PROOFS_TO_AGGREGATE;
 use wormhole_circuit::circuit::{CircuitFragment, C, D, F};
 use wormhole_circuit::inputs::CircuitInputs;
@@ -16,9 +16,9 @@ const CIRCUIT_CONFIG: CircuitConfig = CircuitConfig::standard_recursion_config()
 fn run_test() -> anyhow::Result<plonky2::plonk::proof::ProofWithPublicInputs<F, C, D>> {
     let (mut builder, mut pw) = setup_test_builder_and_witness(false);
     let targets = WormholeProofAggregatorTargets::new(&mut builder, CIRCUIT_CONFIG);
-    WormholeProofAggregator::circuit(&targets, &mut builder);
+    WormholeProofAggregatorInner::circuit(&targets, &mut builder);
 
-    let aggregator = WormholeProofAggregator::new();
+    let aggregator = WormholeProofAggregatorInner::new(CIRCUIT_CONFIG);
     aggregator.fill_targets(&mut pw, targets)?;
     build_and_prove_test(builder, pw)
 }

--- a/tests/src/aggregator/mod.rs
+++ b/tests/src/aggregator/mod.rs
@@ -1,2 +1,3 @@
-#[cfg(test)]
+#![cfg(test)]
+pub mod aggregator_tests;
 pub mod circuit_tests;


### PR DESCRIPTION
This PR adds an abstraction layer to the aggregator circuit. Among other things, this enables things like proof buffers and aggregation without reconstructing circuit data.